### PR TITLE
None Type in Device Name Fix

### DIFF
--- a/triones.py
+++ b/triones.py
@@ -12,7 +12,7 @@ async def discover():
     """Discover Bluetooth LE devices."""
     devices = await BleakScanner.discover()
     LOGGER.debug("Discovered devices: %s", [{"address": device.address, "name": device.name} for device in devices])
-    return [device for device in devices if device.name.lower().startswith("triones") or device.name.lower().startswith("ledble")]
+    return [device for device in devices if device.name is not None and (device.name.lower().startswith("triones") or device.name.lower().startswith("ledble"))]
 
 def create_status_callback(future: asyncio.Future):
     def callback(sender: int, data: bytearray):


### PR DESCRIPTION
Some Bluetooth devices are returned with the `None` type in their name. When iterating through the device, the None type is not handled and causes an error.